### PR TITLE
added support for auth in the otel-worker-cli

### DIFF
--- a/otel-worker-cli/src/commands/client.rs
+++ b/otel-worker-cli/src/commands/client.rs
@@ -19,6 +19,10 @@ pub struct Args {
         default_value = "http://127.0.0.1:6767"
     )]
     pub base_url: Url,
+
+    /// Bearer token for authentication. If not provided, will try to read from AUTH_TOKEN environment variable.
+    #[arg(global = true, short, long, env = "AUTH_TOKEN")]
+    pub auth_token: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -32,7 +36,7 @@ pub enum Command {
 
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
-        Command::Spans(args) => spans::handle_command(args).await,
-        Command::Traces(args) => traces::handle_command(args).await,
+        Command::Spans(spans_args) => spans::handle_command(spans_args, args.auth_token).await,
+        Command::Traces(traces_args) => traces::handle_command(traces_args, args.auth_token).await,
     }
 }

--- a/otel-worker-cli/src/commands/client.rs
+++ b/otel-worker-cli/src/commands/client.rs
@@ -20,7 +20,7 @@ pub struct Args {
     )]
     pub base_url: Url,
 
-    /// Bearer token for authentication. If not provided, will try to read from AUTH_TOKEN environment variable.
+    /// Bearer token for authentication.
     #[arg(global = true, short, long, env = "AUTH_TOKEN")]
     pub auth_token: Option<String>,
 }
@@ -36,7 +36,7 @@ pub enum Command {
 
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
-        Command::Spans(spans_args) => spans::handle_command(spans_args, args.auth_token).await,
-        Command::Traces(traces_args) => traces::handle_command(traces_args, args.auth_token).await,
+        Command::Spans(args) => spans::handle_command(args).await,
+        Command::Traces(args) => traces::handle_command(args).await,
     }
 }

--- a/otel-worker-cli/src/commands/client/spans.rs
+++ b/otel-worker-cli/src/commands/client/spans.rs
@@ -22,11 +22,11 @@ pub enum Command {
     Delete(DeleteArgs),
 }
 
-pub async fn handle_command(args: Args) -> Result<()> {
+pub async fn handle_command(args: Args, auth_token: Option<String>) -> Result<()> {
     match args.command {
-        Command::Get(args) => handle_get(args).await,
-        Command::List(args) => handle_list(args).await,
-        Command::Delete(args) => handle_delete(args).await,
+        Command::Get(args) => handle_get(args, auth_token).await,
+        Command::List(args) => handle_list(args, auth_token).await,
+        Command::Delete(args) => handle_delete(args, auth_token).await,
     }
 }
 
@@ -43,8 +43,11 @@ pub struct GetArgs {
     pub base_url: Url,
 }
 
-async fn handle_get(args: GetArgs) -> Result<()> {
-    let api_client = ApiClient::new(args.base_url.clone());
+async fn handle_get(args: GetArgs, auth_token: Option<String>) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url.clone());
+    if let Some(token) = auth_token {
+        api_client = api_client.with_bearer_token(token);
+    }
 
     let result = api_client.span_get(args.trace_id, args.span_id).await?;
 
@@ -63,8 +66,11 @@ pub struct ListArgs {
     pub base_url: Url,
 }
 
-async fn handle_list(args: ListArgs) -> Result<()> {
-    let api_client = ApiClient::new(args.base_url.clone());
+async fn handle_list(args: ListArgs, auth_token: Option<String>) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url.clone());
+    if let Some(token) = auth_token {
+        api_client = api_client.with_bearer_token(token);
+    }
 
     let result = api_client.span_list(args.trace_id).await?;
 
@@ -86,8 +92,11 @@ pub struct DeleteArgs {
     pub base_url: Url,
 }
 
-async fn handle_delete(args: DeleteArgs) -> Result<()> {
-    let api_client = ApiClient::new(args.base_url.clone());
+async fn handle_delete(args: DeleteArgs, auth_token: Option<String>) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url.clone());
+    if let Some(token) = auth_token {
+        api_client = api_client.with_bearer_token(token);
+    }
 
     api_client.span_delete(args.trace_id, args.span_id).await?;
 

--- a/otel-worker-cli/src/commands/client/spans.rs
+++ b/otel-worker-cli/src/commands/client/spans.rs
@@ -22,11 +22,11 @@ pub enum Command {
     Delete(DeleteArgs),
 }
 
-pub async fn handle_command(args: Args, auth_token: Option<String>) -> Result<()> {
+pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
-        Command::Get(args) => handle_get(args, auth_token).await,
-        Command::List(args) => handle_list(args, auth_token).await,
-        Command::Delete(args) => handle_delete(args, auth_token).await,
+        Command::Get(args) => handle_get(args).await,
+        Command::List(args) => handle_list(args).await,
+        Command::Delete(args) => handle_delete(args).await,
     }
 }
 
@@ -38,16 +38,16 @@ pub struct GetArgs {
     /// SpanID - hex encoded
     pub span_id: String,
 
-    /// Base url of the otel-worker server.
     #[arg(from_global)]
     pub base_url: Url,
+
+    #[arg(from_global)]
+    pub auth_token: Option<String>,
 }
 
-async fn handle_get(args: GetArgs, auth_token: Option<String>) -> Result<()> {
-    let mut api_client = ApiClient::new(args.base_url.clone());
-    if let Some(token) = auth_token {
-        api_client = api_client.with_bearer_token(token);
-    }
+async fn handle_get(args: GetArgs) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url);
+    api_client.set_bearer_token(args.auth_token);
 
     let result = api_client.span_get(args.trace_id, args.span_id).await?;
 
@@ -61,16 +61,16 @@ pub struct ListArgs {
     /// TraceID - hex encoded
     pub trace_id: String,
 
-    /// Base url of the otel-worker server.
     #[arg(from_global)]
     pub base_url: Url,
+
+    #[arg(from_global)]
+    pub auth_token: Option<String>,
 }
 
-async fn handle_list(args: ListArgs, auth_token: Option<String>) -> Result<()> {
-    let mut api_client = ApiClient::new(args.base_url.clone());
-    if let Some(token) = auth_token {
-        api_client = api_client.with_bearer_token(token);
-    }
+async fn handle_list(args: ListArgs) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url);
+    api_client.set_bearer_token(args.auth_token);
 
     let result = api_client.span_list(args.trace_id).await?;
 
@@ -87,16 +87,16 @@ pub struct DeleteArgs {
     /// SpanID - hex encoded
     pub span_id: String,
 
-    /// Base url of the otel-worker server.
     #[arg(from_global)]
     pub base_url: Url,
+
+    #[arg(from_global)]
+    pub auth_token: Option<String>,
 }
 
-async fn handle_delete(args: DeleteArgs, auth_token: Option<String>) -> Result<()> {
-    let mut api_client = ApiClient::new(args.base_url.clone());
-    if let Some(token) = auth_token {
-        api_client = api_client.with_bearer_token(token);
-    }
+async fn handle_delete(args: DeleteArgs) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url);
+    api_client.set_bearer_token(args.auth_token);
 
     api_client.span_delete(args.trace_id, args.span_id).await?;
 

--- a/otel-worker-cli/src/commands/client/traces.rs
+++ b/otel-worker-cli/src/commands/client/traces.rs
@@ -22,11 +22,11 @@ pub enum Command {
     Delete(DeleteArgs),
 }
 
-pub async fn handle_command(args: Args) -> Result<()> {
+pub async fn handle_command(args: Args, auth_token: Option<String>) -> Result<()> {
     match args.command {
-        Command::Get(args) => handle_get(args).await,
-        Command::List(args) => handle_list(args).await,
-        Command::Delete(args) => handle_delete(args).await,
+        Command::Get(args) => handle_get(args, auth_token).await,
+        Command::List(args) => handle_list(args, auth_token).await,
+        Command::Delete(args) => handle_delete(args, auth_token).await,
     }
 }
 
@@ -40,8 +40,11 @@ pub struct GetArgs {
     pub base_url: Url,
 }
 
-async fn handle_get(args: GetArgs) -> Result<()> {
-    let api_client = ApiClient::new(args.base_url.clone());
+async fn handle_get(args: GetArgs, auth_token: Option<String>) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url.clone());
+    if let Some(token) = auth_token {
+        api_client = api_client.with_bearer_token(token);
+    }
 
     let result = api_client.trace_get(args.trace_id).await?;
 
@@ -57,8 +60,11 @@ pub struct ListArgs {
     pub base_url: Url,
 }
 
-async fn handle_list(args: ListArgs) -> Result<()> {
-    let api_client = ApiClient::new(args.base_url.clone());
+async fn handle_list(args: ListArgs, auth_token: Option<String>) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url.clone());
+    if let Some(token) = auth_token {
+        api_client = api_client.with_bearer_token(token);
+    }
 
     let result = api_client.trace_list().await?;
 
@@ -77,8 +83,11 @@ pub struct DeleteArgs {
     pub base_url: Url,
 }
 
-async fn handle_delete(args: DeleteArgs) -> Result<()> {
-    let api_client = ApiClient::new(args.base_url.clone());
+async fn handle_delete(args: DeleteArgs, auth_token: Option<String>) -> Result<()> {
+    let mut api_client = ApiClient::new(args.base_url.clone());
+    if let Some(token) = auth_token {
+        api_client = api_client.with_bearer_token(token);
+    }
 
     api_client.trace_delete(args.trace_id).await?;
 

--- a/otel-worker-cli/src/commands/client/traces.rs
+++ b/otel-worker-cli/src/commands/client/traces.rs
@@ -22,11 +22,11 @@ pub enum Command {
     Delete(DeleteArgs),
 }
 
-pub async fn handle_command(args: Args, auth_token: Option<String>) -> Result<()> {
+pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
-        Command::Get(args) => handle_get(args, auth_token).await,
-        Command::List(args) => handle_list(args, auth_token).await,
-        Command::Delete(args) => handle_delete(args, auth_token).await,
+        Command::Get(args) => handle_get(args).await,
+        Command::List(args) => handle_list(args).await,
+        Command::Delete(args) => handle_delete(args).await,
     }
 }
 
@@ -35,16 +35,16 @@ pub struct GetArgs {
     /// TraceID - hex encoded
     pub trace_id: String,
 
-    /// Base url of the otel-worker server.
     #[arg(from_global)]
     pub base_url: Url,
+
+    #[arg(from_global)]
+    pub auth_token: Option<String>,
 }
 
-async fn handle_get(args: GetArgs, auth_token: Option<String>) -> Result<()> {
+async fn handle_get(args: GetArgs) -> Result<()> {
     let mut api_client = ApiClient::new(args.base_url.clone());
-    if let Some(token) = auth_token {
-        api_client = api_client.with_bearer_token(token);
-    }
+    api_client.set_bearer_token(args.auth_token);
 
     let result = api_client.trace_get(args.trace_id).await?;
 
@@ -55,16 +55,16 @@ async fn handle_get(args: GetArgs, auth_token: Option<String>) -> Result<()> {
 
 #[derive(clap::Args, Debug)]
 pub struct ListArgs {
-    /// Base url of the otel-worker server.
     #[arg(from_global)]
     pub base_url: Url,
+
+    #[arg(from_global)]
+    pub auth_token: Option<String>,
 }
 
-async fn handle_list(args: ListArgs, auth_token: Option<String>) -> Result<()> {
+async fn handle_list(args: ListArgs) -> Result<()> {
     let mut api_client = ApiClient::new(args.base_url.clone());
-    if let Some(token) = auth_token {
-        api_client = api_client.with_bearer_token(token);
-    }
+    api_client.set_bearer_token(args.auth_token);
 
     let result = api_client.trace_list().await?;
 
@@ -78,16 +78,16 @@ pub struct DeleteArgs {
     /// TraceID - hex encoded
     pub trace_id: String,
 
-    /// Base url of the otel-worker server.
     #[arg(from_global)]
     pub base_url: Url,
+
+    #[arg(from_global)]
+    pub auth_token: Option<String>,
 }
 
-async fn handle_delete(args: DeleteArgs, auth_token: Option<String>) -> Result<()> {
+async fn handle_delete(args: DeleteArgs) -> Result<()> {
     let mut api_client = ApiClient::new(args.base_url.clone());
-    if let Some(token) = auth_token {
-        api_client = api_client.with_bearer_token(token);
-    }
+    api_client.set_bearer_token(args.auth_token);
 
     api_client.trace_delete(args.trace_id).await?;
 


### PR DESCRIPTION
I noticed the CLI does not support the Bearer token needed to interact with the otel-worker

DX is as follows for instance:

```
cargo run -- client traces list -b http://localhost:8787 --auth-token 'your-secret-token-here'
```

or just set the `AUTH_TOKEN` env var