### PR TITLE
Make the query params for listing traces optional

### DIFF
--- a/otel-worker-core/src/api/handlers/traces.rs
+++ b/otel-worker-core/src/api/handlers/traces.rs
@@ -13,11 +13,11 @@ use tracing::error;
 #[tracing::instrument(skip_all)]
 pub async fn traces_list_handler(
     State(store): State<BoxedStore>,
-    Query(TracesListQueryParams { limit, time }): Query<TracesListQueryParams>,
+    Query(params): Query<TracesListQueryParams>,
 ) -> Result<Json<Vec<TraceSummary>>, ApiServerError<TraceListError>> {
     let tx = store.start_readonly_transaction().await?;
 
-    let traces = store.traces_list(&tx, limit, time.map(Into::into)).await?;
+    let traces = store.traces_list(&tx, params.limit, params.time.map(Into::into)).await?;
 
     let mut result = Vec::with_capacity(20);
 

--- a/otel-worker-core/src/data/models.rs
+++ b/otel-worker-core/src/data/models.rs
@@ -70,7 +70,8 @@ impl From<api::models::Span> for Span {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
+#[serde(default)]
 pub struct TracesListQueryParams {
     pub limit: Option<u32>,
 


### PR DESCRIPTION
API requests fail to `/v1/traces` if the query parameters are not provided. 

This PR adds a fix for that 