### PR TITLE
Change default port that we launch on to 24318

### DIFF
--- a/otel-worker/wrangler.toml
+++ b/otel-worker/wrangler.toml
@@ -2,6 +2,9 @@ name = "otel-worker"
 main = "build/worker/shim.mjs"
 compatibility_date = "2024-07-30"
 
+[dev]
+port = 24318
+
 [[durable_objects.bindings]]
 name = "WEBSOCKET_HIBERNATION_SERVER"
 class_name = "WebSocketHibernationServer"


### PR DESCRIPTION
Since we expect that this worker could run as an adjacent service for another worker locally, it'd be nice not to take the default port for workers. I've chosen `24318` as it is similar to `4318` (standard otel collector http endpoint), but it won't conflict with another otel collector running locally 