### PR TITLE
Create session management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_with",
  "strum",
  "test-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,8 +779,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1394,7 +1406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1548,7 +1560,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "console_error_panic_hook",
- "getrandom",
+ "getrandom 0.2.15",
  "otel-worker-core",
  "serde",
  "serde_json",
@@ -1606,6 +1618,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1795,7 +1808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.15",
  "rand",
  "ring",
  "rustc-hash 2.1.1",
@@ -1880,7 +1893,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1981,7 +1994,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -2913,6 +2926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +2960,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3214,6 +3245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/otel-worker-cli/Cargo.toml
+++ b/otel-worker-cli/Cargo.toml
@@ -56,6 +56,7 @@ rust-mcp-schema = { version = "0.1.0", features = ["2024_11_05"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_urlencoded = "0.7.1"
 serde_with = { version = "3.8.1" }
 strum = { version = "0.26", features = ["derive"] }
 thiserror = { version = "2.0" }

--- a/otel-worker-cli/Cargo.toml
+++ b/otel-worker-cli/Cargo.toml
@@ -72,6 +72,7 @@ tracing = { version = "0.1" }
 tracing-opentelemetry = { version = "0.28" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.5" }
+uuid = { version = "1.15.1", features = ["v4"] }
 
 [dev-dependencies]
 test-log = { version = "0.2", default-features = false, features = ["trace"] }

--- a/otel-worker-cli/src/commands/client/spans.rs
+++ b/otel-worker-cli/src/commands/client/spans.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Subcommand;
-use otel_worker_core::api::client;
+use otel_worker_core::api::client::ApiClient;
 use std::io::stdout;
 use url::Url;
 
@@ -46,7 +46,7 @@ pub struct GetArgs {
 }
 
 async fn handle_get(args: GetArgs) -> Result<()> {
-    let api_client = client::builder(args.base_url.clone())
+    let api_client = ApiClient::builder(args.base_url.clone())
         .set_bearer_token(args.auth_token)
         .build();
 
@@ -70,7 +70,7 @@ pub struct ListArgs {
 }
 
 async fn handle_list(args: ListArgs) -> Result<()> {
-    let api_client = client::builder(args.base_url.clone())
+    let api_client = ApiClient::builder(args.base_url.clone())
         .set_bearer_token(args.auth_token)
         .build();
 
@@ -97,7 +97,7 @@ pub struct DeleteArgs {
 }
 
 async fn handle_delete(args: DeleteArgs) -> Result<()> {
-    let api_client = client::builder(args.base_url.clone())
+    let api_client = ApiClient::builder(args.base_url.clone())
         .set_bearer_token(args.auth_token)
         .build();
 

--- a/otel-worker-cli/src/commands/client/traces.rs
+++ b/otel-worker-cli/src/commands/client/traces.rs
@@ -1,7 +1,7 @@
 use crate::commands::util::parse_rfc3339_from_str;
 use anyhow::Result;
 use clap::Subcommand;
-use otel_worker_core::api::client;
+use otel_worker_core::api::client::ApiClient;
 use std::io::stdout;
 use time::OffsetDateTime;
 use url::Url;
@@ -45,7 +45,7 @@ pub struct GetArgs {
 }
 
 async fn handle_get(args: GetArgs) -> Result<()> {
-    let api_client = client::builder(args.base_url.clone())
+    let api_client = ApiClient::builder(args.base_url.clone())
         .set_bearer_token(args.auth_token)
         .build();
 
@@ -74,7 +74,7 @@ pub struct ListArgs {
 }
 
 async fn handle_list(args: ListArgs) -> Result<()> {
-    let api_client = client::builder(args.base_url.clone())
+    let api_client = ApiClient::builder(args.base_url.clone())
         .set_bearer_token(args.auth_token)
         .build();
 
@@ -98,7 +98,7 @@ pub struct DeleteArgs {
 }
 
 async fn handle_delete(args: DeleteArgs) -> Result<()> {
-    let api_client = client::builder(args.base_url.clone())
+    let api_client = ApiClient::builder(args.base_url.clone())
         .set_bearer_token(args.auth_token)
         .build();
 

--- a/otel-worker-cli/src/commands/mcp.rs
+++ b/otel-worker-cli/src/commands/mcp.rs
@@ -431,16 +431,16 @@ async fn handle_client_request(
     let result = match request.request {
         RequestFromClient::ClientRequest(client_request) => match client_request {
             ClientRequest::InitializeRequest(inner_request) => {
-                handle_initialize(state, &session, request.id, inner_request.params).await
+                handle_initialize(state, session, request.id, inner_request.params).await
             }
             ClientRequest::ListResourcesRequest(inner_request) => {
-                handle_resources_list(state, &session, request.id, inner_request.params).await
+                handle_resources_list(state, session, request.id, inner_request.params).await
             }
             ClientRequest::ReadResourceRequest(inner_request) => {
-                handle_resources_read(state, &session, request.id, inner_request.params).await
+                handle_resources_read(state, session, request.id, inner_request.params).await
             }
             ClientRequest::PingRequest(inner_request) => {
-                handle_ping(state, &session, request.id, inner_request.params).await
+                handle_ping(state, session, request.id, inner_request.params).await
             }
             _inner_request => {
                 error!(

--- a/otel-worker-cli/src/commands/mcp.rs
+++ b/otel-worker-cli/src/commands/mcp.rs
@@ -87,9 +87,8 @@ pub async fn handle_command(args: Args) -> Result<()> {
 
                 // We are only interested in 1 event, so we just ignore everything else
                 if let models::ServerMessageDetails::SpanAdded(_span_added) = msg.details {
-                    let data = ResourceListChangedNotification::new(None);
-                    let message = ServerMessage::Notification(data.into());
-                    ws_state.broadcast(message).await;
+                    let notification = ResourceListChangedNotification::new(None);
+                    ws_state.broadcast_notification(notification).await;
                 }
             }
         }
@@ -148,6 +147,15 @@ impl McpState {
         for session in sessions.values() {
             session.send_message(message.clone()).await
         }
+    }
+
+    /// Send a json-rpc notification to all MCP clients connected to this
+    /// instance.
+    #[allow(dead_code)]
+    async fn broadcast_notification(&self, notification: impl Into<NotificationFromServer>) {
+        let notification = ServerJsonrpcNotification::new(notification.into());
+        let message = ServerMessage::Notification(notification);
+        self.broadcast(message).await
     }
 }
 

--- a/otel-worker-cli/src/commands/mcp.rs
+++ b/otel-worker-cli/src/commands/mcp.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use futures::StreamExt;
-use otel_worker_core::api::client::{self, ApiClient};
+use otel_worker_core::api::client::ApiClient;
 use otel_worker_core::api::models;
 use rust_mcp_schema::schema_utils::{
     ClientJsonrpcRequest, ClientMessage, NotificationFromServer, RequestFromClient,
@@ -59,7 +59,7 @@ pub async fn handle_command(args: Args) -> Result<()> {
     // have to worry about error handling inside the [`tokio::task`].
     let websocket_url = get_ws_url(&args.otel_worker_url)?;
 
-    let api_client = client::builder(args.otel_worker_url)
+    let api_client = ApiClient::builder(args.otel_worker_url)
         .set_bearer_token(args.otel_worker_token)
         .build();
 

--- a/otel-worker-cli/src/commands/mcp.rs
+++ b/otel-worker-cli/src/commands/mcp.rs
@@ -395,7 +395,7 @@ pub enum Transport {
 
 async fn handle_client_message(
     state: &McpState,
-    session: McpSession,
+    session: &McpSession,
     client_message: ClientMessage,
 ) {
     match client_message {
@@ -416,7 +416,7 @@ async fn handle_client_message(
 
 async fn handle_client_request(
     state: &McpState,
-    session: McpSession,
+    session: &McpSession,
     request: ClientJsonrpcRequest,
 ) {
     let request_id = request.id.clone();
@@ -464,7 +464,7 @@ async fn handle_client_request(
 
 async fn handle_client_notification(
     _state: &McpState,
-    _session: McpSession,
+    _session: &McpSession,
     notification: rust_mcp_schema::schema_utils::ClientJsonrpcNotification,
 ) {
     info!(?notification, "Received a notification!");
@@ -472,12 +472,12 @@ async fn handle_client_notification(
 
 async fn handle_client_response(
     _state: &McpState,
-    _session: McpSession,
+    _session: &McpSession,
     response: rust_mcp_schema::schema_utils::ClientJsonrpcResponse,
 ) {
     info!(?response, "Received a response!");
 }
 
-async fn handle_client_error(_state: &McpState, _session: McpSession, error: JsonrpcError) {
+async fn handle_client_error(_state: &McpState, _session: &McpSession, error: JsonrpcError) {
     info!(?error, "Received a client error!");
 }

--- a/otel-worker-cli/src/commands/mcp.rs
+++ b/otel-worker-cli/src/commands/mcp.rs
@@ -120,7 +120,7 @@ impl McpState {
         }
     }
 
-    async fn register_session(&mut self) -> (String, McpSession, Receiver<ServerMessage>) {
+    async fn register_session(&mut self) -> (String, Receiver<ServerMessage>) {
         let mut id: i32 = 0;
         loop {
             // TODO: Refactor poor mans id management to use UUID
@@ -132,7 +132,8 @@ impl McpState {
                 Entry::Occupied(_) => continue,
                 Entry::Vacant(entry) => {
                     let (mcp_session, notifications_rx) = McpSession::new();
-                    break (id, entry.insert(mcp_session).clone(), notifications_rx);
+                    entry.insert(mcp_session);
+                    break (id, notifications_rx);
                 }
             }
         }

--- a/otel-worker-cli/src/commands/mcp.rs
+++ b/otel-worker-cli/src/commands/mcp.rs
@@ -139,8 +139,8 @@ impl McpState {
         }
     }
 
-    async fn get_session(&mut self, session_id: impl Into<String>) -> Option<McpSession> {
-        self.sessions.read().await.get(&session_id.into()).cloned()
+    async fn get_session(&mut self, session_id: impl AsRef<str>) -> Option<McpSession> {
+        self.sessions.read().await.get(session_id.as_ref()).cloned()
     }
 
     /// Send a message to all MCP clients.

--- a/otel-worker-cli/src/commands/mcp/sse.rs
+++ b/otel-worker-cli/src/commands/mcp/sse.rs
@@ -65,7 +65,7 @@ async fn json_rpc_handler(
     let Some(session) = state.get_session(&session_id).await else {
         debug!(
             ?session_id,
-            "json-rpc endpoint retrieved a sessions which doesn't exists"
+            "json-rpc endpoint was called with a session_id which doesn't exists"
         );
         return (StatusCode::BAD_REQUEST, "session not found").into_response();
     };

--- a/otel-worker-cli/src/commands/mcp/sse.rs
+++ b/otel-worker-cli/src/commands/mcp/sse.rs
@@ -72,7 +72,7 @@ async fn json_rpc_handler(
 
     // Handle to message in a separate task and immediately return ACCEPTED
     tokio::spawn(async move {
-        super::handle_client_message(&state, session, client_message).await;
+        super::handle_client_message(&state, &session, client_message).await;
     });
 
     StatusCode::ACCEPTED.into_response()

--- a/otel-worker-cli/src/commands/mcp/sse.rs
+++ b/otel-worker-cli/src/commands/mcp/sse.rs
@@ -91,7 +91,7 @@ async fn sse_handler(
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     debug!("MCP client connected to the SSE handler");
 
-    let (session_id, session_notifications) = state.register_session().await;
+    let (session_id, messages) = state.register_session().await;
 
     // This message needs to be send as soon as the client accesses the page.
     let initial_event = futures::stream::once(async move {
@@ -104,7 +104,7 @@ async fn sse_handler(
 
     // This stream will contain all the ServerMessages which are converted to
     // Sse Events.
-    let events = ReceiverStream::new(session_notifications).map(|message| {
+    let events = ReceiverStream::new(messages).map(|message| {
         Ok(Event::default()
             .event("message")
             .json_data(message)

--- a/otel-worker-cli/src/commands/mcp/stdio.rs
+++ b/otel-worker-cli/src/commands/mcp/stdio.rs
@@ -8,7 +8,11 @@ use tracing::{debug, error, info};
 pub(crate) async fn serve(mut state: McpState) -> Result<()> {
     // Stdio only has support for a single session, so just start that at the
     // beginning and use it throughout the life cycle.
-    let (_session_id, session, mut messages) = state.register_session().await;
+    let (session_id, mut messages) = state.register_session().await;
+    let session = state
+        .get_session(session_id)
+        .await
+        .expect("should have session");
 
     // spawn two tasks, one to read lines on stdin, parse payloads, and dispatch
     // to super::*. The other has to read from notifications and serialize them

--- a/otel-worker-cli/src/commands/mcp/stdio.rs
+++ b/otel-worker-cli/src/commands/mcp/stdio.rs
@@ -31,7 +31,7 @@ pub(crate) async fn serve(mut state: McpState) -> Result<()> {
             let client_message: ClientMessage =
                 serde_json::from_str(&line).expect("todo: handle error state");
 
-            super::handle_client_message(&state, session.clone(), client_message).await
+            super::handle_client_message(&state, &session, client_message).await
         }
     });
 

--- a/otel-worker-cli/src/commands/mcp/stdio.rs
+++ b/otel-worker-cli/src/commands/mcp/stdio.rs
@@ -15,7 +15,7 @@ pub(crate) async fn serve(mut state: McpState) -> Result<()> {
         .expect("should have session");
 
     // spawn two tasks, one to read lines on stdin, parse payloads, and dispatch
-    // to super::*. The other has to read from notifications and serialize them
+    // to super::*. The other has to read from messages and serialize them
     // to stdout.
     let stdin_loop = tokio::spawn(async move {
         let mut stdin = BufReader::new(tokio::io::stdin());
@@ -52,7 +52,7 @@ pub(crate) async fn serve(mut state: McpState) -> Result<()> {
                     debug!("stdout loop has written the message");
                 }
                 None => {
-                    error!("TODO: Unable to read from notifications channel");
+                    error!("TODO: Unable to read from messages channel");
                     break;
                 }
             };

--- a/otel-worker-core/src/api/client.rs
+++ b/otel-worker-core/src/api/client.rs
@@ -26,10 +26,6 @@ use tracing::trace;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use url::Url;
 
-pub fn builder(base_url: Url) -> ApiClientBuilder {
-    ApiClientBuilder::new(base_url)
-}
-
 pub struct ApiClientBuilder {
     base_url: Url,
     bearer_token: Option<String>,
@@ -91,6 +87,10 @@ impl ApiClient {
         Self {
             inner: Arc::new(inner),
         }
+    }
+
+    pub fn builder(base_url: Url) -> ApiClientBuilder {
+        ApiClientBuilder::new(base_url)
     }
 }
 


### PR DESCRIPTION
Resolves: #16

Part of the change is to move the message sending from a generic part to the individual handlers themselves. This is due to the fact that some handlers don't send any messages and some might send more than one. If there is a error returned from the handler it will still be handled by a generic part.